### PR TITLE
feat: Add output format options (#7)

### DIFF
--- a/src/__tests__/formatter.test.ts
+++ b/src/__tests__/formatter.test.ts
@@ -62,4 +62,10 @@ describe("formatter", () => {
       expect(parsed).toEqual([]);
     });
   });
+
+  it("should throw an error for invalid formats", () => {
+    const mockProjects = [{ name: "project1", path: "/projects" }] as Dirent[];
+
+    expect(() => formatter(mockProjects, "invalid")).toThrow("Invalid format");
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -17,9 +17,10 @@ export default function formatter(
         path: `${dir.path}/${dir.name}`,
       };
     });
-    console.log("output", output);
     return JSON.stringify(output);
-  } else {
+  } else if (format === "path") {
     return directories.map((dir) => `${dir.path}/${dir.name}`).join("\n");
+  } else {
+    throw new Error(`Invalid format: ${format}. Use path, tsv, or json.`);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,26 @@
-import { program } from "commander";
+import { program, Option } from "commander";
 import Scanner from "./scanner.js";
+import formatter from "./formatter.js";
 
 program
   .name("ondesided")
   .description("A CLI to manage your side projects.")
   .version("0.1.0")
   .option("-d, --dir <path>", "Directory to scan")
+  .addOption(
+    new Option("-f, --format <type>", "Format output: path, tsv, json")
+      .choices(["path", "tsv", "json"])
+      .default("path"),
+  )
   .action((options) => {
     const scanner = new Scanner();
     const projectDirectories = scanner.scanFolder(options.dir);
-    console.log(projectDirectories);
+
+    const output = formatter(projectDirectories, options.format);
+
+    if (output) {
+      console.log(output);
+    }
   });
 
 program.parse();


### PR DESCRIPTION
Added support for multiple output formats (path, tsv, json) for better interoperability with Unix tools.

## Changes
- Created `formatter.ts` with support for three output formats:
  - `path`: One path per line (default)
  - `tsv`: Tab-separated name and path
  - `json`: JSON array with name and path properties
- Added `--format` option to CLI with format validation
- Comprehensive unit tests for all formats and edge cases

## Testing

- [x] Unit tests for all three formats
- [x] Empty array handling (returns "" for path/tsv, "[]" for json)
- [x] Invalid format error handling
- [x] All acceptance criteria met

Closes #7