### PR TITLE
refactor: replace deprecated Dirent.path with parentPath

### DIFF
--- a/src/__tests__/formatter.test.ts
+++ b/src/__tests__/formatter.test.ts
@@ -4,9 +4,9 @@ import formatter from "../formatter.js";
 
 describe("formatter", () => {
   const mockProjects = [
-    { name: "project1", path: "/projects" },
-    { name: "project2", path: "/projects" },
-    { name: "project3", path: "/projects" },
+    { name: "project1", parentPath: "/projects" },
+    { name: "project2", parentPath: "/projects" },
+    { name: "project3", parentPath: "/projects" },
   ] as Dirent[];
 
   describe("path format (default)", () => {
@@ -64,8 +64,12 @@ describe("formatter", () => {
   });
 
   it("should throw an error for invalid formats", () => {
-    const mockProjects = [{ name: "project1", path: "/projects" }] as Dirent[];
+    const mockProjects = [
+      { name: "project1", parentPath: "/projects" },
+    ] as Dirent[];
 
-    expect(() => formatter(mockProjects, "invalid")).toThrow("Invalid format");
+    expect(() => formatter(mockProjects, "invalid" as any)).toThrow(
+      "Invalid format",
+    );
   });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -8,18 +8,18 @@ export default function formatter(
 ): string {
   if (format === "tsv") {
     return directories
-      .map((dir) => `${dir.name}\t${dir.path}/${dir.name}`)
+      .map((dir) => `${dir.name}\t${dir.parentPath}/${dir.name}`)
       .join("\n");
   } else if (format === "json") {
     const output = directories.map((dir) => {
       return {
         name: dir.name,
-        path: `${dir.path}/${dir.name}`,
+        path: `${dir.parentPath}/${dir.name}`,
       };
     });
     return JSON.stringify(output);
   } else if (format === "path") {
-    return directories.map((dir) => `${dir.path}/${dir.name}`).join("\n");
+    return directories.map((dir) => `${dir.parentPath}/${dir.name}`).join("\n");
   } else {
     throw new Error(`Invalid format: ${format}. Use path, tsv, or json.`);
   }

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -13,7 +13,7 @@ class Scanner {
         return false;
       }
 
-      return fs.readdirSync(`${path}/${dir.name}`).includes(".git");
+      return fs.readdirSync(`${dir.parentPath}/${dir.name}`).includes(".git");
     });
     return projectDirectories;
   }


### PR DESCRIPTION
Update codebase to use parentPath instead of deprecated path property on Dirent objects.

## Changes

- replaced every occurent of Dirent `path` property (now deprecated) with `parentPath`

Closes #8