### PR TITLE
feat: output detail levels and isGitRepo refactor

### DIFF
--- a/src/__tests__/formatter.test.ts
+++ b/src/__tests__/formatter.test.ts
@@ -1,75 +1,210 @@
 import { describe, expect, it } from "vitest";
-import formatter from "../formatter.js";
+import formatter, { pickPropValue, setProp } from "../formatter.js";
 import type { Project } from "../scanner.js";
 
+const mockProjects: Project[] = [
+	{
+		name: "project1",
+		path: "/projects/project1",
+		isGitRepo: true,
+		git: { branch: "main", lastCommitMessage: "fix: bug", lastCommitDate: new Date("2026-01-15T10:30:00Z"), isDirty: false },
+	},
+	{
+		name: "project2",
+		path: "/projects/project2",
+		isGitRepo: true,
+		git: { branch: "dev", lastCommitMessage: "feat: new", lastCommitDate: new Date("2026-01-14T09:00:00Z"), isDirty: true },
+	},
+	{
+		name: "project3",
+		path: "/projects/project3",
+		isGitRepo: false,
+		git: null,
+	},
+];
+
+describe("pickPropValue", () => {
+	const project = mockProjects[0]!;
+
+	it("returns a top-level property", () => {
+		expect(pickPropValue(project, "name")).toBe("project1");
+	});
+
+	it("returns a nested property", () => {
+		expect(pickPropValue(project, "git.branch")).toBe("main");
+	});
+
+	it("returns null for non-existent property", () => {
+		expect(pickPropValue(project, "notAProp")).toBeNull();
+		expect(pickPropValue(project, "git.notAProp")).toBeNull();
+	});
+
+	it("returns null for null property", () => {
+		expect(pickPropValue(mockProjects[2]!, "git.branch")).toBeNull();
+	});
+
+	it("returns a Date property", () => {
+		expect(pickPropValue(project, "git.lastCommitDate")).toBe(project.git!.lastCommitDate);
+	});
+
+	it("returns a boolean property", () => {
+		expect(pickPropValue(project, "git.isDirty")).toBe(false);
+	});
+});
+
+describe("setProp", () => {
+	it("sets a top-level property on an empty object", () => {
+		const obj: any = {};
+		setProp(obj, ["name"], "project-1");
+		expect(obj).toEqual({ name: "project-1" });
+	});
+
+	it("sets a nested property on an empty object", () => {
+		const obj: any = {};
+		setProp(obj, ["git", "branch"], "main");
+		expect(obj).toEqual({ git: { branch: "main" } });
+	});
+
+	it("sets multiple nested properties on the same object", () => {
+		const obj: any = {};
+		setProp(obj, ["git", "branch"], "main");
+		setProp(obj, ["git", "isDirty"], true);
+		expect(obj).toEqual({ git: { branch: "main", isDirty: true } });
+	});
+
+	it("overwrites an existing property", () => {
+		const obj: any = { name: "old" };
+		setProp(obj, ["name"], "new");
+		expect(obj).toEqual({ name: "new" });
+	});
+
+	it("does not affect unrelated properties", () => {
+		const obj: any = { foo: 1 };
+		setProp(obj, ["bar"], 2);
+		expect(obj).toEqual({ foo: 1, bar: 2 });
+	});
+
+	it("creates intermediate objects if missing", () => {
+		const obj: any = { git: null };
+		setProp(obj, ["git", "branch"], "main");
+		expect(obj).toEqual({ git: { branch: "main" } });
+	});
+});
+
 describe("formatter", () => {
-  const mockProjects = [
-    { name: "project1", path: "/projects/project1" },
-    { name: "project2", path: "/projects/project2" },
-    { name: "project3", path: "/projects/project3" },
-  ] as Project[];
 
-  describe("path format (default)", () => {
-    it("should return a string of paths separated by a new line", () => {
-      const result = formatter(mockProjects);
+	describe("pretty format (default)", () => {
+		it("should include a counter for each project", () => {
+			const result = formatter(mockProjects, "pretty", "minimal");
+			expect(result).toContain("#1");
+			expect(result).toContain("#2");
+			expect(result).toContain("#3");
+		});
 
-      expect(result).toBe(
-        "/projects/project1\n/projects/project2\n/projects/project3",
-      );
-    });
+		it("should show name as top-level and path indented", () => {
+			const result = formatter(mockProjects, "pretty", "minimal");
+			const lines = result.trim().split("\n");
+			const projectLine = lines.find(l => l.startsWith("Project:"))!;
+			const pathLine = lines.find(l => l.trimStart().startsWith("Path:"))!;
+			expect(projectLine).toBeDefined();
+			expect(pathLine.startsWith("  ")).toBe(true);
+		});
 
-    it("should return an empty string when no projects are found", () => {
-      const mockProjects = [] as Project[];
-      const result = formatter(mockProjects);
-      expect(result).toBe("");
-    });
-  });
+		it("should align values at the same column", () => {
+			const result = formatter(mockProjects, "pretty", "full");
+			const lines = result.trim().split("\n").filter(l => l.includes(":"));
+			const valueColumns = lines.map(l => l.indexOf(":") + 1 + l.slice(l.indexOf(":") + 1).match(/^ */)![0].length);
+			expect(new Set(valueColumns).size).toBe(1);
+		});
 
-  describe("tsv format", () => {
-    it("should return name and path separated by tabs, one per line", () => {
-      const result = formatter(mockProjects, "tsv");
-      expect(result).toBe(
-        "project1\t/projects/project1\nproject2\t/projects/project2\nproject3\t/projects/project3",
-      );
-    });
+		it("should show git fields with full detail", () => {
+			const result = formatter(mockProjects, "pretty", "full");
+			expect(result).toContain("main");
+			expect(result).toContain("fix: bug");
+		});
 
-    it("should return an empty string when no projects are found", () => {
-      const mockProjects = [] as Project[];
-      const result = formatter(mockProjects, "tsv");
-      expect(result).toBe("");
-    });
-  });
+		it("should return an empty string when no projects are found", () => {
+			const result = formatter([], "pretty");
+			expect(result).toBe("");
+		});
+	});
 
-  describe("json format", () => {
-    it("should return a json array containing objects with project name and folder", () => {
-      const result = formatter(mockProjects, "json");
-      const parsed = JSON.parse(result);
+	describe("tsv format", () => {
+		it("should return one path per line with path-only detail", () => {
+			const result = formatter(mockProjects, "tsv", "path-only");
+			expect(result).toBe(
+				"/projects/project1\n/projects/project2\n/projects/project3",
+			);
+		});
 
-      const expected = [
-        { name: "project1", path: "/projects/project1" },
-        { name: "project2", path: "/projects/project2" },
-        { name: "project3", path: "/projects/project3" },
-      ];
+		it("should return name and path separated by tabs with minimal detail", () => {
+			const result = formatter(mockProjects, "tsv", "minimal");
+			expect(result).toBe(
+				"project1\t/projects/project1\nproject2\t/projects/project2\nproject3\t/projects/project3",
+			);
+		});
 
-      expect(parsed).toEqual(expected);
-    });
+		it("should return an empty string when no projects are found", () => {
+			const result = formatter([], "tsv");
+			expect(result).toBe("");
+		});
+	});
 
-    it("should return an empty JSON string when no projects are found", () => {
-      const mockProjects = [] as Project[];
-      const result = formatter(mockProjects, "json");
-      const parsed = JSON.parse(result);
+	describe("json format", () => {
+		it("should return only paths with path-only detail", () => {
+			const parsed = JSON.parse(formatter(mockProjects, "json", "path-only"));
+			expect(parsed).toEqual([
+				{ path: "/projects/project1" },
+				{ path: "/projects/project2" },
+				{ path: "/projects/project3" },
+			]);
+		});
 
-      expect(parsed).toEqual([]);
-    });
-  });
+		it("should return name and path with minimal detail", () => {
+			const parsed = JSON.parse(formatter(mockProjects, "json", "minimal"));
+			expect(parsed).toEqual([
+				{ name: "project1", path: "/projects/project1" },
+				{ name: "project2", path: "/projects/project2" },
+				{ name: "project3", path: "/projects/project3" },
+			]);
+		});
 
-  it("should throw an error for invalid formats", () => {
-    const mockProjects = [
-      { name: "project1", path: "/projects" },
-    ] as Project[];
+		it("should return name, path, isGitRepo and last commit date with simple detail", () => {
+			const parsed = JSON.parse(formatter(mockProjects, "json", "simple"));
+			expect(parsed[0]).toMatchObject({
+				name: "project1",
+				path: "/projects/project1",
+				isGitRepo: true,
+				git: { lastCommitDate: "2026-01-15T10:30:00.000Z" },
+			});
+		});
 
-    expect(() => formatter(mockProjects, "invalid" as any)).toThrow(
-      "Invalid format",
-    );
-  });
+		it("should return all git fields with full detail", () => {
+			const parsed = JSON.parse(formatter(mockProjects, "json", "full"));
+			expect(parsed[0]).toEqual({
+				name: "project1",
+				path: "/projects/project1",
+				isGitRepo: true,
+				git: { branch: "main", lastCommitMessage: "fix: bug", lastCommitDate: "2026-01-15T10:30:00.000Z", isDirty: false },
+			});
+		});
+
+		it("should include isGitRepo false and null git fields for non-git projects", () => {
+			const parsed = JSON.parse(formatter(mockProjects, "json", "full"));
+			expect(parsed[2]).toEqual({
+				name: "project3",
+				path: "/projects/project3",
+				isGitRepo: false,
+				git: { branch: null, lastCommitMessage: null, lastCommitDate: null, isDirty: null },
+			});
+		});
+
+		it("should return an empty array when no projects are found", () => {
+			expect(JSON.parse(formatter([], "json"))).toEqual([]);
+		});
+	});
+
+	it("should throw an error for invalid formats", () => {
+		expect(() => formatter(mockProjects, "invalid" as any)).toThrow("Invalid format");
+	});
 });

--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -294,11 +294,11 @@ describe("getGitInfo", () => {
 
 			const info = getGitInfo(repoPath);
 
-			expect(info.isGitRepo).toBe(true);
-			expect(info.branch).toBe("test-branch");
-			expect(info.lastCommitMessage).toBe("init");
-			expect(info.lastCommitDate).toBeInstanceOf(Date);
-			expect(info.isDirty).toBe(false);
+			expect(info).not.toBeNull();
+			expect(info!.branch).toBe("test-branch");
+			expect(info!.lastCommitMessage).toBe("init");
+			expect(info!.lastCommitDate).toBeInstanceOf(Date);
+			expect(info!.isDirty).toBe(false);
 		} finally {
 			fs.rmSync(repoPath, { recursive: true, force: true });
 		}
@@ -324,11 +324,11 @@ describe("getGitInfo", () => {
 
 			const info = getGitInfo(repoPath);
 
-			expect(info.isGitRepo).toBe(true);
-			expect(info.branch).toBe("test-branch");
-			expect(info.lastCommitMessage).toBe("init");
-			expect(info.lastCommitDate).toBeInstanceOf(Date);
-			expect(info.isDirty).toBe(true);
+			expect(info).not.toBeNull();
+			expect(info!.branch).toBe("test-branch");
+			expect(info!.lastCommitMessage).toBe("init");
+			expect(info!.lastCommitDate).toBeInstanceOf(Date);
+			expect(info!.isDirty).toBe(true);
 		} finally {
 			fs.rmSync(repoPath, { recursive: true, force: true });
 		}
@@ -347,17 +347,17 @@ describe("getGitInfo", () => {
 
 			const info = getGitInfo(repoPath);
 
-			expect(info.isGitRepo).toBe(true);
-			expect(info.branch).toBe("test-branch");
-			expect(info.lastCommitMessage).toBeNull();
-			expect(info.lastCommitDate).toBeNull();
-			expect(info.isDirty).toBe(false);
+			expect(info).not.toBeNull();
+			expect(info!.branch).toBe("test-branch");
+			expect(info!.lastCommitMessage).toBeNull();
+			expect(info!.lastCommitDate).toBeNull();
+			expect(info!.isDirty).toBe(false);
 		} finally {
 			fs.rmSync(repoPath, { recursive: true, force: true });
 		}
 	});
 
-	it("returns null git fields for an existing non-git directory", () => {
+	it("returns null for an existing non-git directory", () => {
 		const nonRepoPath = path.join(
 			os.tmpdir(),
 			"ondesided-git-info-nonrepo-" + Date.now(),
@@ -365,31 +365,18 @@ describe("getGitInfo", () => {
 
 		try {
 			fs.mkdirSync(nonRepoPath);
-
-			expect(getGitInfo(nonRepoPath)).toEqual({
-				isGitRepo: false,
-				branch: null,
-				lastCommitMessage: null,
-				lastCommitDate: null,
-				isDirty: null,
-			});
+			expect(getGitInfo(nonRepoPath)).toBeNull();
 		} finally {
 			fs.rmSync(nonRepoPath, { recursive: true, force: true });
 		}
 	});
 
-	it("returns null git fields for a path that does not exist", () => {
+	it("returns null for a path that does not exist", () => {
 		const missingPath = path.join(
 			os.tmpdir(),
 			"ondesided-git-info-missing-" + Date.now(),
 		);
 
-		expect(getGitInfo(missingPath)).toEqual({
-			isGitRepo: false,
-			branch: null,
-			lastCommitMessage: null,
-			lastCommitDate: null,
-			isDirty: null,
-		});
+		expect(getGitInfo(missingPath)).toBeNull();
 	});
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,26 +1,123 @@
-import { Dirent } from "fs";
 import type { Project } from "./scanner.js";
 
-type OutputFormat = "path" | "tsv" | "json";
+type OutputFormat = "pretty" | "tsv" | "json";
+type OutputDetail = "path-only" | "minimal" | "simple" | "full";
+
+export function pickPropValue(
+	obj: Project,
+	path: string[] | string,
+): Date | string | boolean | null {
+	if (typeof path === "string") {
+		path = path.split(".");
+	}
+	const result = path.reduce((acc, key) => {
+		return acc && key in acc ? (acc as any)[key] : null;
+	}, obj);
+	return result instanceof Date ||
+		typeof result === "string" ||
+		typeof result === "boolean"
+		? result
+		: null;
+}
+
+export function setProp(
+	targetObj: Record<string, any>,
+	props: string[] | string,
+	value: Date | string | number | boolean | null,
+): Record<string, any> {
+	if (typeof props === "string") {
+		props = props.split(".");
+	}
+
+	props.reduce((acc, current, i, array) => {
+		if (i === array.length - 1) {
+			acc[current] = value;
+			return acc;
+		}
+		if (current in acc && acc[current] !== null) {
+			return acc[current];
+		} else {
+			acc[current] = {};
+			return acc[current];
+		}
+	}, targetObj);
+
+	return targetObj;
+}
 
 export default function formatter(
 	projects: Project[],
-	format: OutputFormat = "path",
+	format: OutputFormat = "pretty",
+	detail: OutputDetail = "path-only",
 ): string {
+	const detailProps: Record<OutputDetail, string[]> = {
+		"path-only": ["path"],
+		minimal: ["name", "path"],
+		simple: ["name", "path", "isGitRepo", "git.lastCommitDate"],
+		full: [
+			"name",
+			"path",
+			"isGitRepo",
+			"git.branch",
+			"git.isDirty",
+			"git.lastCommitMessage",
+			"git.lastCommitDate",
+		],
+	};
+
 	if (format === "tsv") {
+		const props = detailProps[detail];
 		return projects
-			.map((project) => `${project.name}\t${project.path}`)
+			.map((project) => props.map(p => pickPropValue(project, p) ?? "").join("\t"))
 			.join("\n");
 	} else if (format === "json") {
+		const props = detailProps[detail];
 		const output = projects.map((project) => {
-			return {
-				name: project.name,
-				path: project.path,
-			};
+			const result = {};
+			for (const prop of props) {
+				const value = pickPropValue(project, prop);
+				setProp(result, prop, value);
+			}
+			return result;
 		});
 		return JSON.stringify(output);
-	} else if (format === "path") {
-		return projects.map((project) => project.path).join("\n");
+	} else if (format === "pretty") {
+		const props = detailProps[detail];
+		const prettyLabels: Record<string, string> = {
+			name: "Project",
+			path: "Path",
+			isGitRepo: "Git repo",
+			"git.branch": "Current active branch",
+			"git.isDirty": "Dirty",
+			"git.lastCommitMessage": "Last commit",
+			"git.lastCommitDate": "Last commit date",
+		};
+		const indent = "  ";
+		const labelPad = Math.max(
+			...props.map(p => {
+				const label = prettyLabels[p] ?? p;
+				return p === "name" ? label.length : indent.length + label.length;
+			}),
+		) + 1;
+		return projects.map((project, i) => {
+		const projectCounter = `#${i + 1}`;
+			let lines = [projectCounter];
+			for (const prop of props) {
+				let value = pickPropValue(project, prop);
+				if (value instanceof Date) {
+					value = value.toLocaleString("en-GB", { year: "numeric", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" });
+				}
+				if (value !== null && value !== "") {
+					const label = prettyLabels[prop] ?? prop;
+					if (prop === "name") {
+						lines.push(`${label}:${" ".repeat(labelPad - label.length)}${value}`);
+					} else {
+						lines.push(`${indent}${label}:${" ".repeat(labelPad - indent.length - label.length)}${value}`);
+					}
+				}
+			}
+			return `\n${lines.join("\n")}\n`;
+		}).join("\n");
 	} else {
 		throw new Error(`Invalid format: ${format}. Use path, tsv, or json.`);
 	}

--- a/src/git.ts
+++ b/src/git.ts
@@ -2,7 +2,6 @@ import { execSync } from "child_process";
 import type { ExecSyncOptionsWithStringEncoding } from "child_process";
 
 export interface GitInfo {
-	isGitRepo: boolean;
 	lastCommitDate: Date | null;
 	lastCommitMessage: string | null;
 	branch: string | null;
@@ -28,23 +27,14 @@ const gitCommand = (path: string, command: string): string | null => {
 	}
 };
 
-export default function getGitInfo(path: string): GitInfo {
-	if (!isGitRepo(path)) {
-		return {
-			isGitRepo: false,
-			lastCommitDate: null,
-			lastCommitMessage: null,
-			branch: null,
-			isDirty: null,
-		};
-	}
+export default function getGitInfo(path: string): GitInfo | null {
+	if (!isGitRepo(path)) return null;
 
 	const branch = getBranch(path);
 	const { message, date } = getLastCommit(path);
 	const isDirty = isRepoDirty(path);
 
 	return {
-		isGitRepo: true,
 		lastCommitDate: date,
 		lastCommitMessage: message,
 		branch,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 import { program, Option } from "commander";
 import Scanner from "./scanner.js";
 import formatter from "./formatter.js";
-import { getLastCommit } from "./git.js";
+import getGitInfo from "./git.js";
 
 program
 	.name("ondesided")
@@ -12,23 +12,21 @@ program
 	.option("-d, --dir <path>", "Directory to scan")
 	.addOption(
 		new Option("-f, --format <type>", "Format output: path, tsv, json")
-			.choices(["path", "tsv", "json"])
-			.default("path"),
+			.choices(["pretty", "tsv", "json"])
+			.default("pretty"),
+	)
+	.addOption(
+		new Option("--detail <level>", "Description...")
+			.choices(["path-only", "minimal", "simple", "full"])
+			.default("path-only"),
 	)
 	.action((options) => {
 		const scanner = new Scanner();
 		const projectDirectories = scanner.scanFolder(options.dir);
 		const enrichedProjects = projectDirectories.map((project) => {
-			const { message, date } = getLastCommit(project.path);
-
-			project.git = {
-				isGitRepo: true,
-				lastCommitDate: date,
-				lastCommitMessage: message,
-				branch: null,
-				isDirty: null,
-			};
-
+			const git = getGitInfo(project.path);
+			project.isGitRepo = git !== null;
+			project.git = git;
 			return project;
 		});
 
@@ -57,7 +55,7 @@ program
 				return projA.name.localeCompare(projB.name);
 			}
 		});
-		const output = formatter(enrichedProjects, options.format);
+		const output = formatter(enrichedProjects, options.format, options.detail);
 
 		if (output) {
 			console.log(output);

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -5,6 +5,7 @@ import type { GitInfo } from "./git.js";
 export type Project = {
   name: string;
   path: string;
+  isGitRepo: boolean;
   git: GitInfo | null;
 };
 
@@ -27,7 +28,8 @@ class Scanner {
     return projectDirectories.map((dir) => ({
       name: dir.name,
       path: this.getDirentFullPath(dir, folderPath),
-      git: null
+      isGitRepo: false,
+      git: null,
     }));
   }
 


### PR DESCRIPTION
## Summary

- Adds `--detail` flag with four levels (`path-only`, `minimal`, `simple`, `full`) across all output formats
- Redesigns pretty format: 
  - numbered project entries
  - sub-fields indented under Project 
  - values column-aligned
- Moves `isGitRepo` from `GitInfo` to top-level `Project` 
  - `getGitInfo` returns `GitInfo | null` instead of an object with `isGitRepo: false`
- `index.ts` now calls `getGitInfo` instead of just `getLastCommit`, populating all git fields (branch, isDirty, lastCommit)

## Testing

- `npm test` passes (54 tests)
- Pretty format renders correctly for `minimal`, `simple`, `full` detail
- JSON output includes `isGitRepo` and null git fields for non-git projects
- `--detail` flag works end-to-end from CLI

Closes #23 