### PR TITLE
feat: add sort options for projects

### DIFF
--- a/src/__tests__/projects.test.ts
+++ b/src/__tests__/projects.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { sortProjects, addGitInfoToProject } from "../projects.js";
+import type { Project } from "../scanner.js";
+
+const makeProject = (
+	name: string,
+	date: Date | null = null,
+	isGitRepo: boolean = false,
+): Project => ({
+	name,
+	path: `/projects/${name}`,
+	isGitRepo,
+	git: isGitRepo
+		? { branch: "main", lastCommitDate: date, lastCommitMessage: null, isDirty: false }
+		: null,
+});
+
+describe("sortProjects", () => {
+	it("sorts by date descending, most recent first", () => {
+		const projects = [
+			makeProject("old", new Date("2024-01-01"), true),
+			makeProject("new", new Date("2026-01-01"), true),
+			makeProject("mid", new Date("2025-01-01"), true),
+		];
+		const result = sortProjects(projects);
+		expect(result.map((p) => p.name)).toEqual(["new", "mid", "old"]);
+	});
+
+	it("puts projects with a date before projects without", () => {
+		const projects = [
+			makeProject("no-date"),
+			makeProject("has-date", new Date("2025-01-01"), true),
+		];
+		const result = sortProjects(projects);
+		expect(result[0]!.name).toBe("has-date");
+	});
+
+	it("sorts projects without dates alphabetically", () => {
+		const projects = [
+			makeProject("banana"),
+			makeProject("apple"),
+			makeProject("mango"),
+		];
+		const result = sortProjects(projects);
+		expect(result.map((p) => p.name)).toEqual(["apple", "banana", "mango"]);
+	});
+});
+
+describe("addGitInfoToProject", () => {
+	let repoPath: string;
+	let nonRepoPath: string;
+
+	beforeAll(() => {
+		repoPath = path.join(os.tmpdir(), "ondesided-test-enrich-repo-" + Date.now());
+		nonRepoPath = path.join(os.tmpdir(), "ondesided-test-enrich-nonrepo-" + Date.now());
+		fs.mkdirSync(repoPath);
+		fs.mkdirSync(nonRepoPath);
+		execSync("git init", { cwd: repoPath });
+	});
+
+	afterAll(() => {
+		fs.rmSync(repoPath, { recursive: true, force: true });
+		fs.rmSync(nonRepoPath, { recursive: true, force: true });
+	});
+
+	it("sets isGitRepo to true for a git repo", () => {
+		const project = makeProject("my-project", null, false);
+		project.path = repoPath;
+		const result = addGitInfoToProject(project);
+		expect(result.isGitRepo).toBe(true);
+		expect(result.git).not.toBeNull();
+	});
+
+	it("sets isGitRepo to false for a non-git directory", () => {
+		const project = makeProject("not-a-repo", null, false);
+		project.path = nonRepoPath;
+		const result = addGitInfoToProject(project);
+		expect(result.isGitRepo).toBe(false);
+		expect(result.git).toBeNull();
+	});
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,52 +3,9 @@
 import { program, Option } from "commander";
 import Scanner from "./scanner.js";
 import formatter from "./formatter.js";
-import getGitInfo from "./git.js";
-import type { Project } from "./scanner.js";
+import { addGitInfoToProject, parseSortOption, sortProjects } from "./projects.js";
 
-/** Fetches and attaches git information to a project. */
 
-function enrichProject(project: Project): Project {
-	const git = getGitInfo(project.path);
-	project.isGitRepo = git !== null;
-	project.git = git;
-	return project;
-}
-
-/**
- * Sorts projects by last commit date, most recent first.
- * Projects without commits come last, sorted alphabetically.
- */
-
-function sortProjects(projects: Project[]): Project[] {
-	// Sort priority:
-	// 1) projects with a commit date come first.
-	// 2) newer commit dates come before older ones.
-	// 3) if both have no commits, sort by project name.
-	projects.sort((projA, projB) => {
-		// this is mostly to shut TypeScript up
-		// .git or date can't be missing at this point, but in case let's
-		// set it to null
-		const timeA = projA.git?.lastCommitDate?.getTime() ?? null;
-		const timeB = projB.git?.lastCommitDate?.getTime() ?? null;
-
-		// both have a date: descending order (most recent first).
-		if (timeA !== null && timeB !== null) {
-			return timeB - timeA;
-			// only A has a date: A comes first
-		} else if (timeA !== null) {
-			return -1;
-			// only B has a date: B comes first
-		} else if (timeB !== null) {
-			return 1;
-		} else {
-			// neither has a date: alphabetical fallback
-			return projA.name.localeCompare(projB.name);
-		}
-	});
-
-  return projects;
-}
 
 program
 	.name("ondesided")
@@ -61,15 +18,29 @@ program
 			.default("pretty"),
 	)
 	.addOption(
-		new Option("--detail <level>", "Determines which properties will be included in the output.")
+		new Option(
+			"--detail <level>",
+			"Determines which properties will be included in the output.",
+		)
 			.choices(["path-only", "minimal", "simple", "full"])
 			.default("path-only"),
+	)
+	.addOption(
+		new Option("--sort <type>", "Sort")
+			.choices(["date", "date-asc", "name", "name-desc"])
+			.default("date"),
 	)
 	.action((options) => {
 		const scanner = new Scanner();
 		const projectDirectories = scanner.scanFolder(options.dir);
-		const enrichedProjects = projectDirectories.map(enrichProject);
-		const sortedProjects = sortProjects(enrichedProjects);
+		const projectsWithGitInfo = projectDirectories.map(addGitInfoToProject);
+
+		const parsedSortOption = parseSortOption(options.sort);
+		const sortedProjects = sortProjects(
+			projectsWithGitInfo,
+			parsedSortOption.by,
+			parsedSortOption.order,
+		);
 
 		const output = formatter(
 			sortedProjects,

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -1,0 +1,74 @@
+import getGitInfo from "./git.js";
+import type { Project } from "./scanner.js";
+
+type SortBy = "name" | "date";
+type SortOrder = "asc" | "desc";
+type SortOptions = {
+	by: SortBy;
+	order: SortOrder;
+};
+
+/** Fetches and attaches git information to a project. */
+
+export function addGitInfoToProject(project: Project): Project {
+	const git = getGitInfo(project.path);
+	project.isGitRepo = git !== null;
+	project.git = git;
+	return project;
+}
+
+export function parseSortOption(sortOption: string): SortOptions {
+	const sortOptions: Record<string, SortOptions> = {
+		date: { by: "date", order: "desc" }, // Most recent first (on top)
+		"date-asc": { by: "date", order: "asc" }, // Oldest first (on top)
+		name: { by: "name", order: "asc" }, // A to Z
+		"name-desc": { by: "name", order: "desc" }, // Z to A
+	};
+	return sortOptions[sortOption] ?? { by: "date", order: "desc" };
+}
+
+/**
+ * Sorts projects in-place by the given field and order.
+ * When sorting by date, projects without commits come last,
+ * sorted alphabetically.
+ */
+
+export function sortProjects(
+	projects: Project[],
+	by: SortBy = "date",
+	order: SortOrder = "desc",
+): Project[] {
+	const direction = order === "desc" ? 1 : -1;
+
+	if (by === "name") {
+		projects.sort((a, b) => a.name.localeCompare(b.name) * -direction);
+	} else {
+		// Sort priority:
+		// 1) projects with a commit date come first.
+		// 2) newer commit dates come before older ones.
+		// 3) if both have no commits, sort by project name.
+		projects.sort((projA, projB) => {
+			// this is mostly to shut TypeScript up
+			// .git or date can't be missing at this point, but in case let's
+			// set it to null
+			const timeA = projA.git?.lastCommitDate?.getTime() ?? null;
+			const timeB = projB.git?.lastCommitDate?.getTime() ?? null;
+
+			// both have a date: sort by date according to direction
+			if (timeA !== null && timeB !== null) {
+				return (timeB - timeA) * direction;
+				// only A has a date: A comes first (regardless of direction)
+			} else if (timeA !== null) {
+				return -direction;
+				// only B has a date: B comes first (regardless of direction)
+			} else if (timeB !== null) {
+				return direction;
+			} else {
+				// neither has a date: alphabetical fallback
+				return projA.name.localeCompare(projB.name);
+			}
+		});
+	}
+
+	return projects;
+}


### PR DESCRIPTION
## Summary

- Added `--sort` CLI option with choices: `date`, `date-asc`, `name`, `name-desc`
- Extracted `sortProjects` and `addGitInfoToProject` into `projects.ts`
- Added `parseSortOption` to map CLI strings to sort field and order

Closes #24 
